### PR TITLE
Extend support backwards to Node v14

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config.InitialOptions = {
 	globals: {
 		"ts-jest": {
 			tsconfig: "<rootDir>/tsconfig.json",
+			diagnostics: true,
 		},
 	},
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@oly_op/tsconfig": "1.0.24",
 				"@types/jest": "28.1.8",
 				"@types/lodash-es": "4.17.6",
-				"@types/node": "18.7.18",
+				"@types/node": "14.18.29",
 				"@types/pg": "8.6.5",
 				"@typescript-eslint/eslint-plugin": "5.38.0",
 				"copy-and-watch": "0.1.6",
@@ -47,7 +47,7 @@
 				"typescript": "4.8.3"
 			},
 			"engines": {
-				"node": ">=16.7"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@apollo/server": "^4.0.0-alpha",
@@ -2406,9 +2406,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
+			"version": "14.18.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+			"integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
 			"dev": true
 		},
 		"node_modules/@types/node-fetch": {
@@ -12275,9 +12275,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.18",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
-			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
+			"version": "14.18.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+			"integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
 			"dev": true
 		},
 		"@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "https://github.com/olyop/apollo-server-fastify.git"
 	},
 	"engines": {
-		"node": ">=16.7"
+		"node": ">=14"
 	},
 	"type": "module",
 	"main": "build/cjs/index.js",
@@ -62,7 +62,7 @@
 		"@oly_op/tsconfig": "1.0.24",
 		"@types/jest": "28.1.8",
 		"@types/lodash-es": "4.17.6",
-		"@types/node": "18.7.18",
+		"@types/node": "14.18.29",
 		"@types/pg": "8.6.5",
 		"@typescript-eslint/eslint-plugin": "5.38.0",
 		"copy-and-watch": "0.1.6",

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,8 +3,15 @@
 	"extends": ["config:base"],
 	"automergeType": "branch",
 	"dependencyDashboard": false,
-	"packageRules": [{
-		"updateTypes": ["minor", "patch", "pin", "digest"],
-		"automerge": true
-	}]
+	"packageRules": [
+		{
+			"updateTypes": ["minor", "patch", "pin", "digest"],
+			"automerge": true
+		},
+	   {
+      matchPackageNames: ["@types/node"],
+      matchBaseBranches: ["version-4"],
+      allowedVersions: "14.x"
+    },
+	]
 }

--- a/src/drain-plugin.ts
+++ b/src/drain-plugin.ts
@@ -17,10 +17,10 @@ export function fastifyApolloDrainPlugin<TContext extends BaseContext>(
 			return {
 				async drainServer() {
 					if ("closeAllConnections" in fastify.server) {
-						const timeout = setTimeout(
-							() => fastify.server.closeAllConnections(),
-							10_000,
-						)
+						const timeout = setTimeout(() => {
+							// eslint-disable-next-line
+              (fastify.server as any).closeAllConnections()
+						}, 10_000)
 						await fastify.close()
 						clearTimeout(timeout)
 					}


### PR DESCRIPTION
For a project like this, we want to sensibly support as many users
as we can. Node v14 is still LTS, so we should claim support for
it (and it's easy for us to do so). Fastify v4 also tests against
Node v14. Next year, v14 will be EOL at which time we can drop
support for it in a major version release.

Since we support back to v14, we should downgrade the node types
to match so that we get typescript errors if we try to use > v14
Node APIs.

I also added `diagnostics: true` to the ts-jest config so we get
test failures when we have TS errors in test files.